### PR TITLE
Add PINN-based travel-time modelling toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # pinn_location
-pinn进行地震定位
+
+基于PINN的地震走时表建模与位置反演工具集。
+
+## 功能概述
+
+- 使用共享主干 + P/S双头输出的多层感知机 (`TauPSNet`) 来预测走时。
+- 支持随机傅里叶特征增强的输入表示，可提升复杂速度结构下的拟合能力。
+- 通过 `compute_travel_time_table` 高效计算网格化走时表，批量处理多个震源和台站以充分利用 GPU。
+- `gibbs_mh_location_sampler` 基于预测走时与观测值执行 Gibbs-MH 采样，允许部分缺失的 P/S 走时。
+- 训练数据集中自动忽略缺失走时（NaN），保持训练稳定性。
+
+## 快速开始
+
+```python
+import torch
+from pinn_location import (
+    TauPSNet,
+    TauPSNetConfig,
+    TraveltimeDataset,
+    TrainingConfig,
+    train_taunet,
+    compute_travel_time_table,
+    Observations,
+    SamplerConfig,
+    gibbs_mh_location_sampler,
+    build_feats,
+)
+
+# 构造样例数据
+stations = torch.rand(128, 3) * 100.0  # 台站坐标
+sources = torch.rand(128, 3) * 100.0   # 地震坐标
+travel_times = torch.rand(128, 2)      # 对应的 P/S 走时，可包含 NaN 表示缺失
+
+# 训练走时网络
+model = TauPSNet(TauPSNetConfig())
+dataset = TraveltimeDataset(stations, sources, travel_times)
+train_taunet(model, dataset, TrainingConfig(epochs=10))
+
+# 计算走时表
+grid = torch.rand(512, 3) * 100.0
+p_table, s_table = compute_travel_time_table(model, stations, grid)
+
+# 进行 Gibbs-MH 采样
+t_obs = torch.rand(stations.shape[0], 2)
+obs = Observations(stations, t_obs, sigma_p=0.1, sigma_s=0.2)
+config = SamplerConfig(step_std=torch.tensor([1.0, 1.0, 1.0]), num_iterations=1000)
+initial = torch.tensor([50.0, 50.0, 10.0])
+
+samples = gibbs_mh_location_sampler(
+    lambda sta, hypo: model(build_feats(sta, hypo)),
+    obs,
+    initial,
+    config,
+)
+print(samples.shape)
+```
+
+## 依赖
+
+- Python 3.10+
+- PyTorch 2.x
+
+## 许可证
+
+MIT

--- a/pinn_location/__init__.py
+++ b/pinn_location/__init__.py
@@ -1,0 +1,20 @@
+"""PINN-based seismic travel-time modelling and location inversion."""
+
+from .features import build_feats
+from .model import TauPSNet, TauPSNetConfig
+from .sampling import Observations, SamplerConfig, gibbs_mh_location_sampler
+from .training import TraveltimeDataset, TrainingConfig, train_taunet
+from .traveltime import compute_travel_time_table
+
+__all__ = [
+    "TauPSNet",
+    "TauPSNetConfig",
+    "build_feats",
+    "compute_travel_time_table",
+    "gibbs_mh_location_sampler",
+    "Observations",
+    "SamplerConfig",
+    "TraveltimeDataset",
+    "TrainingConfig",
+    "train_taunet",
+]

--- a/pinn_location/features.py
+++ b/pinn_location/features.py
@@ -1,0 +1,37 @@
+"""Feature engineering helpers for seismic travel-time prediction."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+
+def build_feats(x: torch.Tensor, xs: torch.Tensor) -> torch.Tensor:
+    """Construct conditional features for the (station, source) pair.
+
+    Parameters
+    ----------
+    x:
+        Tensor of shape ``[N, 3]`` containing station coordinates.
+    xs:
+        Tensor of shape ``[3]`` or ``[N, 3]`` containing earthquake hypocentres.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``[N, 13]`` containing the concatenated features
+        ``[x, xs, r, u, d]`` where ``r`` is the offset vector, ``u`` is the
+        normalised ray direction and ``d`` is the epicentral distance.
+    """
+    if xs.dim() == 1:
+        xs = xs.unsqueeze(0).expand_as(x)
+    elif xs.shape[0] != x.shape[0]:
+        raise ValueError("Station and source tensors must have matching length")
+
+    r = x - xs
+    d = torch.linalg.norm(r, dim=-1, keepdim=True).clamp_min(1e-6)
+    u = r / d
+    return torch.cat([x, xs, r, u, d], dim=-1)
+
+
+__all__ = ["build_feats"]

--- a/pinn_location/model.py
+++ b/pinn_location/model.py
@@ -1,0 +1,102 @@
+"""Neural network for predicting P- and S-wave travel times."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+
+@dataclass
+class TauPSNetConfig:
+    """Configuration for :class:`TauPSNet`.
+
+    Attributes
+    ----------
+    in_dim:
+        Dimensionality of the input features. Defaults to ``13`` which matches
+        :func:`pinn_location.features.build_feats`.
+    hidden:
+        Width of the hidden layers.
+    layers:
+        Number of hidden layers.
+    use_fourier_features:
+        Whether to apply Fourier feature mapping prior to the MLP.
+    fourier_features:
+        Number of random Fourier features per input dimension if
+        ``use_fourier_features`` is enabled.
+    fourier_sigma:
+        Bandwidth of the Gaussian used to sample Fourier feature frequencies.
+    dropout:
+        Optional dropout probability applied after each hidden activation.
+    """
+
+    in_dim: int = 13
+    hidden: int = 256
+    layers: int = 6
+    use_fourier_features: bool = True
+    fourier_features: int = 64
+    fourier_sigma: float = 3.0
+    dropout: float = 0.0
+
+
+class FourierFeatures(nn.Module):
+    """Random Fourier feature mapping for coordinate inputs."""
+
+    def __init__(self, in_dim: int, features: int, sigma: float = 10.0) -> None:
+        super().__init__()
+        self.register_buffer("B", torch.randn(in_dim, features) * sigma)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_proj = 2 * torch.pi * x @ self.B
+        return torch.cat([torch.sin(x_proj), torch.cos(x_proj)], dim=-1)
+
+
+class TauPSNet(nn.Module):
+    """Predict joint P- and S-wave travel times for a given event."""
+
+    def __init__(self, config: Optional[TauPSNetConfig] = None) -> None:
+        super().__init__()
+        config = config or TauPSNetConfig()
+        self.config = config
+
+        self.ff = (
+            FourierFeatures(config.in_dim, config.fourier_features, config.fourier_sigma)
+            if config.use_fourier_features
+            else None
+        )
+        d_in = (
+            2 * config.fourier_features
+            if self.ff is not None
+            else config.in_dim
+        )
+
+        layers = []
+        for i in range(config.layers):
+            layers.append(nn.Linear(d_in if i == 0 else config.hidden, config.hidden))
+            layers.append(nn.SiLU())
+            if config.dropout > 0:
+                layers.append(nn.Dropout(config.dropout))
+        self.trunk = nn.Sequential(*layers)
+        self.head_p = nn.Linear(config.hidden, 1)
+        self.head_s = nn.Linear(config.hidden, 1)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        for module in list(self.trunk) + [self.head_p, self.head_s]:
+            if isinstance(module, nn.Linear):
+                nn.init.xavier_uniform_(module.weight)
+                nn.init.zeros_(module.bias)
+
+    def forward(self, feats: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.ff is not None:
+            feats = self.ff(feats)
+        h = self.trunk(feats)
+        tau_p = self.head_p(h)
+        tau_s = self.head_s(h)
+        return tau_p.squeeze(-1), tau_s.squeeze(-1)
+
+
+__all__ = ["TauPSNet", "TauPSNetConfig", "FourierFeatures"]

--- a/pinn_location/sampling.py
+++ b/pinn_location/sampling.py
@@ -1,0 +1,108 @@
+"""Gibbs-within-Metropolis-Hastings sampler for earthquake locations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from .features import build_feats
+
+TraveltimeModel = Callable[[Tensor, Tensor], Tuple[Tensor, Tensor]]
+
+
+@dataclass
+class SamplerConfig:
+    """Configuration controlling the Gibbs-MH sampling procedure."""
+
+    step_std: Tensor
+    num_iterations: int = 2_000
+    burn_in: int = 500
+    thinning: int = 1
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def __post_init__(self) -> None:
+        self.step_std = torch.as_tensor(self.step_std, dtype=torch.float32, device=self.device)
+        if self.step_std.ndim != 1 or self.step_std.shape[0] != 3:
+            raise ValueError("step_std must be broadcastable to a 3-vector [σx, σy, σz]")
+
+
+@dataclass
+class Observations:
+    station_xyz: Tensor
+    travel_times: Tensor
+    sigma_p: float
+    sigma_s: float
+
+    def to(self, device: str) -> "Observations":  # pragma: no cover - simple
+        return Observations(
+            station_xyz=self.station_xyz.to(device),
+            travel_times=self.travel_times.to(device),
+            sigma_p=self.sigma_p,
+            sigma_s=self.sigma_s,
+        )
+
+
+def _log_likelihood(
+    model: TraveltimeModel,
+    obs: Observations,
+    hypo: Tensor,
+) -> Tensor:
+    try:
+        pred_p, pred_s = model(obs.station_xyz, hypo)
+    except TypeError:
+        # Fall back to modules that expect pre-built features
+        feats = build_feats(obs.station_xyz, hypo)
+        pred_p, pred_s = model(feats)
+
+    mask = torch.isfinite(obs.travel_times)
+    logp = torch.tensor(0.0, device=hypo.device)
+    if mask[:, 0].any():
+        diff = obs.travel_times[mask[:, 0], 0] - pred_p[mask[:, 0]]
+        logp = logp - 0.5 * torch.sum(diff.pow(2) / (obs.sigma_p ** 2))
+    if mask[:, 1].any():
+        diff = obs.travel_times[mask[:, 1], 1] - pred_s[mask[:, 1]]
+        logp = logp - 0.5 * torch.sum(diff.pow(2) / (obs.sigma_s ** 2))
+    return logp
+
+
+def gibbs_mh_location_sampler(
+    model: TraveltimeModel,
+    observations: Observations,
+    initial_hypo: Tensor,
+    config: SamplerConfig,
+    *,
+    progress: bool = False,
+) -> Tensor:
+    """Draw posterior samples of the earthquake hypocentre."""
+
+    obs = observations.to(config.device)
+    x = initial_hypo.to(config.device)
+    step_std = config.step_std.to(config.device)
+
+    samples = []
+    log_prob = _log_likelihood(model, obs, x)
+    total = config.num_iterations
+
+    for it in range(total):
+        for dim in range(3):
+            proposal = x.clone()
+            proposal[dim] = proposal[dim] + torch.randn((), device=config.device) * step_std[dim]
+            log_prob_prop = _log_likelihood(model, obs, proposal)
+            log_alpha = log_prob_prop - log_prob
+            if torch.log(torch.rand((), device=config.device)) < log_alpha:
+                x = proposal
+                log_prob = log_prob_prop
+        if it >= config.burn_in and (it - config.burn_in) % config.thinning == 0:
+            samples.append(x.detach().cpu())
+        if progress and (it + 1) % max(1, total // 10) == 0:
+            print(f"Iter {it+1}/{total}")
+    return torch.stack(samples, dim=0)
+
+
+__all__ = [
+    "SamplerConfig",
+    "Observations",
+    "gibbs_mh_location_sampler",
+]

--- a/pinn_location/training.py
+++ b/pinn_location/training.py
@@ -1,0 +1,113 @@
+"""Utilities for training the travel-time neural network."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import Tensor, nn
+from torch.utils.data import Dataset, DataLoader
+
+from .features import build_feats
+from .model import TauPSNet, TauPSNetConfig
+
+
+class TraveltimeDataset(Dataset[Tuple[Tensor, Tensor, Tensor]]):
+    """Dataset of observed P- and S-wave travel times.
+
+    Each item consists of ``(station_xyz, source_xyz, travel_times)`` where the
+    first two tensors have shape ``[3]`` and travel times is ``[2]`` containing
+    ``(tau_p, tau_s)`` in seconds. Missing arrivals can be indicated using
+    ``NaN`` entries, which are automatically masked during training.
+    """
+
+    def __init__(
+        self,
+        stations: Tensor,
+        sources: Tensor,
+        travel_times: Tensor,
+    ) -> None:
+        if stations.shape != sources.shape:
+            raise ValueError("Station and source tensors must have identical shapes")
+        if travel_times.shape != (*stations.shape[:-1], 2):
+            raise ValueError("Travel times must contain both P and S components")
+        self.stations = stations
+        self.sources = sources
+        self.travel_times = travel_times
+
+    def __len__(self) -> int:  # pragma: no cover - simple passthrough
+        return self.stations.shape[0]
+
+    def __getitem__(self, idx: int) -> Tuple[Tensor, Tensor, Tensor]:
+        return (
+            self.stations[idx],
+            self.sources[idx],
+            self.travel_times[idx],
+        )
+
+
+@dataclass
+class TrainingConfig:
+    batch_size: int = 256
+    lr: float = 3e-4
+    weight_decay: float = 1e-6
+    epochs: int = 200
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    grad_clip: Optional[float] = 10.0
+
+
+def _loss(pred_p: Tensor, pred_s: Tensor, target: Tensor) -> Tensor:
+    mask = torch.isfinite(target)
+    if not mask.any():
+        return torch.tensor(0.0, device=target.device, requires_grad=True)
+    loss = 0.0
+    for i, pred in enumerate((pred_p, pred_s)):
+        component_mask = mask[:, i]
+        if component_mask.any():
+            loss = loss + nn.functional.smooth_l1_loss(
+                pred[component_mask], target[component_mask, i]
+            )
+    return loss
+
+
+def train_taunet(
+    model: TauPSNet,
+    dataset: Dataset[Tuple[Tensor, Tensor, Tensor]],
+    config: Optional[TrainingConfig] = None,
+    *,
+    num_workers: int = 0,
+) -> TauPSNet:
+    """Train :class:`TauPSNet` on the provided dataset."""
+    config = config or TrainingConfig()
+    model = model.to(config.device)
+    loader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True, num_workers=num_workers)
+
+    optim = torch.optim.AdamW(model.parameters(), lr=config.lr, weight_decay=config.weight_decay)
+
+    for epoch in range(config.epochs):
+        model.train()
+        running_loss = 0.0
+        for stations, sources, travel_times in loader:
+            stations = stations.to(config.device)
+            sources = sources.to(config.device)
+            travel_times = travel_times.to(config.device)
+
+            feats = build_feats(stations, sources)
+            pred_p, pred_s = model(feats)
+            loss = _loss(pred_p, pred_s, travel_times)
+
+            optim.zero_grad(set_to_none=True)
+            loss.backward()
+            if config.grad_clip is not None:
+                nn.utils.clip_grad_norm_(model.parameters(), config.grad_clip)
+            optim.step()
+
+            running_loss += loss.detach().item() * stations.shape[0]
+        running_loss /= len(dataset)
+        # Lightweight progress logging
+        if (epoch + 1) % max(1, config.epochs // 10) == 0:
+            print(f"Epoch {epoch+1:04d}: loss={running_loss:.4f}")
+    return model
+
+
+__all__ = ["TraveltimeDataset", "TrainingConfig", "train_taunet"]

--- a/pinn_location/traveltime.py
+++ b/pinn_location/traveltime.py
@@ -1,0 +1,43 @@
+"""High-level helpers for generating dense travel-time tables."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import torch
+from torch import Tensor
+
+from .features import build_feats
+from .model import TauPSNet
+
+
+@torch.no_grad()
+def compute_travel_time_table(
+    model: TauPSNet,
+    stations: Tensor,
+    grid_points: Tensor,
+    *,
+    batch_size: int = 4096,
+    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+) -> Tuple[Tensor, Tensor]:
+    """Evaluate P- and S-wave travel times on a 3-D grid."""
+
+    model = model.to(device)
+    stations = stations.to(device)
+    grid_points = grid_points.to(device)
+
+    tau_p = []
+    tau_s = []
+    for i in range(0, grid_points.shape[0], batch_size):
+        xs = grid_points[i : i + batch_size]
+        xs_expand = xs[:, None, :].expand(-1, stations.shape[0], -1)
+        stations_expand = stations[None, :, :].expand(xs.shape[0], -1, -1)
+        feats = build_feats(stations_expand.reshape(-1, 3), xs_expand.reshape(-1, 3))
+        pred_p, pred_s = model(feats)
+        pred_p = pred_p.view(xs.shape[0], stations.shape[0])
+        pred_s = pred_s.view(xs.shape[0], stations.shape[0])
+        tau_p.append(pred_p.cpu())
+        tau_s.append(pred_s.cpu())
+    return torch.cat(tau_p, dim=0), torch.cat(tau_s, dim=0)
+
+
+__all__ = ["compute_travel_time_table"]


### PR DESCRIPTION
## Summary
- add TauPSNet neural architecture with Fourier features for P/S travel-time prediction
- implement dataset, training utilities, and grid-based travel-time table generation
- provide Gibbs-within-MH sampler for earthquake location inversion with missing data handling

## Testing
- python -m compileall pinn_location

------
https://chatgpt.com/codex/tasks/task_e_68dfd6c597a48323a00e4bbbd4dec28e