### PR TITLE
docs: clarify filename conventions and data-generation workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,30 @@ This code focuses on **3-D regional earthquake location** using **P and S first-
 
 ---
 
-## 2. Main Script and Functionality
+## 2. Repository Naming Conventions and Key Scripts
+
+This repository uses filename prefixes and suffixes to indicate task types and dataset/model variants:
+
+- **`location*`**: earthquake location programs.
+  - **`.crop`**: processing raw, unassociated picks.
+  - **`synth`**: synthetic-data experiments.
+  - **`real`**: real-data experiments.
+  - **`pnsn`**: travel-time model configured to handle four phase labels: **Pn, Sn, Pg, Sg**.
+
+- **`travel_time*`**: scripts for training/evaluating travel-time surrogate models.
+  - **`.pinn`**: PINN-based travel-time model training/testing.
+  - **`.real`**: workflows using real datasets.
+
+- **`scripts/`**: data-generation and preprocessing utilities.
+  - **`gen_data_v5*`** variants generate different datasets:
+    - `gen_data_v5.forloc.py`: data for location workflows.
+    - `gen_data_v5.fortest.py`: data for travel-time model testing.
+    - `gen_data_v5.fortrain.py`: data for model training.
+  - Velocity models are generated from **`scripts/run_nonlinloc/`**, which contains a six-step NonLinLoc pipeline (`step1.py` to `step6.export_hyp_catalog.py`).
+
+---
+
+## 3. Main Script and Functionality
 
 The main script is:
 
@@ -97,7 +120,7 @@ Core components:
 
 ---
 
-## 3. Data and File Structure
+## 4. Data and File Structure
 
 The example script expects the following files:
 
@@ -151,9 +174,9 @@ The example script expects the following files:
 
 ---
 
-## 4. Installation and Requirements
+## 5. Installation and Requirements
 
-### 4.1. Dependencies
+### 5.1. Dependencies
 
 - Python 3.9+ (recommended)
 - [PyTorch](https://pytorch.org/) (CPU or GPU)
@@ -169,7 +192,7 @@ pip install torch numpy tqdm
 
 (You may need a specific PyTorch build for CUDA / MPS depending on your hardware.)
 
-### 4.2. Clone and setup
+### 5.2. Clone and setup
 
 ```bash
 git clone <this-repo-url>.git
@@ -187,7 +210,7 @@ ayrdata/china.loc
 
 ---
 
-## 5. Quick Start
+## 6. Quick Start
 
 Once all required files are in place, simply run:
 


### PR DESCRIPTION
### Motivation

- Make it easier for users to understand repository file-name patterns and which scripts to run for different workflows. 
- Clarify how `location*` and `travel_time*` variants map to data types and model/training modes and document the `gen_data_v5.*` and `scripts/run_nonlinloc/` roles.

### Description

- Added a new README section `Repository Naming Conventions and Key Scripts` that documents `location*` meanings (including `.crop`, `synth`, `real`, and `pnsn`) and `travel_time*` suffixes (including `.pinn` and `.real`).
- Documented `scripts/gen_data_v5.forloc.py`, `gen_data_v5.fortest.py`, and `gen_data_v5.fortrain.py` responsibilities and noted that velocity-model generation uses the six-step pipeline in `scripts/run_nonlinloc/` (`step1.py`..`step6.export_hyp_catalog.py`).
- Renumbered downstream README section headings to keep the document structure consistent after insertion.

### Testing

- Ran `git diff -- README.md` to verify the README changes and the diff output showed the inserted section (success).
- Verified working-tree status with `git status --short` and committed the updated `README.md` with `git commit` (success).
- No automated unit tests were required or executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996f2ffec48323a05c2a001de2064d)